### PR TITLE
コミュニティIDから次枠自動移動を行う

### DIFF
--- a/live.go
+++ b/live.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+var errClosed = errors.New("closed")
+
 var (
 	tagThreadBegin  = []byte("<thread ")
 	tagThreadEnd    = append([]byte("/>"), 0)
@@ -51,6 +53,10 @@ type PlayerStatus struct {
 		Port   int    `xml:"port"`
 		Thread int64  `xml:"thread"`
 	} `xml:"ms"`
+
+	Error struct {
+		Code string `xml:"code"`
+	} `xml:"error"`
 }
 
 type Thread struct {
@@ -127,6 +133,11 @@ func (lv *Live) LoadPlayerStatus() error {
 	if err := xml.NewDecoder(res.Body).Decode(&lv.Status); err != nil {
 		return err
 	}
+
+	if lv.Status.Error.Code == "closed" {
+		return errClosed
+	}
+
 	if lv.Status.Status != "ok" {
 		return errors.New("playerstatus should be ok")
 	}


### PR DESCRIPTION
かなり強引な修正で申し訳ないのですが、次枠自動移動があると便利かと思いプルリクさせて頂きます。
そのまま採用して頂いても、ご自身で直して頂いても、必要なければ放置でも構いません。
import順の変更はgoimportsというコマンドで自動的に変わってしまったものなので、もし気に入らなければ直して下さい。